### PR TITLE
Added logWhen method support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,6 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 - `phpstan` minimal version now is `0.10.2`
 
-### Changed
-
-- phpstan version up to 0.10.2
-
 ## v1.1.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v1.2.0
+
+### Added
+
+- `skipLogging` method can be used in events, that implement `ShouldBeLoggedContract` interface (if method calling returns `true` - logging will be skipped) [#1]
+
+[#1]:https://github.com/avto-dev/events-log-laravel/issues/1
+
+### Changed
+
+- `phpstan` minimal version now is `0.10.2`
+
 ## v1.1.0
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog][keepachangelog] and this project adher
 
 - `phpstan` minimal version now is `0.10.2`
 
+### Changed
+
+- phpstan version up to 0.10.2
+
 ## v1.1.0
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 Require this package with composer using the following command (`laravel/framework` version 5.6 and above is required):
 
 ```shell
-$ composer require avto-dev/events-log-laravel "^1.1"
+$ composer require avto-dev/events-log-laravel "^1.2"
 ```
 
 > Installed `composer` is required ([how to install composer][getcomposer]).
@@ -155,6 +155,28 @@ event(new SomeApplicationEvent);
 ```
 
 И быть уверенным в том, что данное событие будет записано в лог-файл. О том, как работают события (events) в Laravel вы можете прочитать по [этой ссылке][laravel_events].
+
+### Условния логирования
+
+В некоторых случаях необходимо добавить условия логгирования события. Для этого вы можете реализовать в классе события метод `skipLogging`:
+
+```php
+
+class YourEvent implements \AvtoDev\EventsLogLaravel\Contracts\ShouldBeLoggedContract
+{
+    /**
+     * Determine if this event should be skipped.
+     *
+     * @return bool
+     */
+    public function skipLogging(): bool
+    {
+        return $this->value > 100;
+    }
+    
+    // ...
+}
+```
 
 ### Дополнительные логгеры
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "phpunit/phpunit": "~7.0",
         "mockery/mockery": "~1.0",
         "symfony/var-dumper": "~3.3 || ^4.0",
-        "phpstan/phpstan": "~0.9 || ^0.10"
+        "phpstan/phpstan": "^0.10.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Contracts/ShouldBeLoggedContract.php
+++ b/src/Contracts/ShouldBeLoggedContract.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace AvtoDev\EventsLogLaravel\Contracts;
 
@@ -40,4 +40,15 @@ interface ShouldBeLoggedContract
      * @return string
      */
     public function eventSource(): string;
+
+    /*
+     * Determine if this event should be skipped.
+     *
+     * Is not required for implementation.
+     *
+     * @see \AvtoDev\EventsLogLaravel\Listeners\EventsSubscriber::skipLoggingConditions()
+     *
+     * @return bool
+     */
+    //public function skipLogging(): bool;
 }

--- a/src/Listeners/EventsSubscriber.php
+++ b/src/Listeners/EventsSubscriber.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
 namespace AvtoDev\EventsLogLaravel\Listeners;
 
@@ -61,7 +61,11 @@ class EventsSubscriber implements EventsSubscriberContract
             : null;
 
         foreach ($event_data as $event_datum) {
-            if (\is_object($event_datum) && $event_datum instanceof ShouldBeLoggedContract) {
+            if (
+                \is_object($event_datum)
+                && $event_datum instanceof ShouldBeLoggedContract
+                && $this->skipEventLogging($event_datum) === false
+            ) {
                 $this->writeEventIntoLog($event_datum, $event_name);
             }
         }
@@ -92,5 +96,17 @@ class EventsSubscriber implements EventsSubscriberContract
     public function subscribe(Dispatcher $events)
     {
         $events->listen('*', [$this, 'onAnyEvents']);
+    }
+
+    /**
+     * Make event additional checks using conditions.
+     *
+     * @param ShouldBeLoggedContract $event
+     *
+     * @return bool
+     */
+    protected function skipEventLogging(ShouldBeLoggedContract $event): bool
+    {
+        return \method_exists($event, $method_name = 'skipLogging') && $event->{$method_name}() === true;
     }
 }

--- a/tests/Listeners/EventsSubscriberTest.php
+++ b/tests/Listeners/EventsSubscriberTest.php
@@ -191,4 +191,44 @@ class EventsSubscriberTest extends AbstractTestCase
 
         $this->assertEquals(\count($wrong_levels), $exceptions_counter);
     }
+
+    /**
+     * Assert logging an event with `skipLogging` method.
+     *
+     * @return void
+     */
+    public function testSkipLoggingTrue(): void
+    {
+        $instance = new EventsSubscriber($this->app->make(LogManager::class), 'test_events_channel');
+
+        $instance->writeEventIntoLog($event = new Stubs\LoggableEventSkipLoggingStub(false));
+
+        $expects = [
+            $event->logMessage(),
+            $event->eventType(),
+            $event->eventSource(),
+            $this->app->environment() . '.' . Str::upper($event->logLevel()),
+        ];
+
+        $expects = array_merge($expects, array_keys($event->logEventExtraData()));
+        $expects = array_merge($expects, array_values($event->logEventExtraData()));
+
+        foreach ($expects as $expect) {
+            $this->assertLogFileContains($expect, 'events.log');
+        }
+    }
+
+    /**
+     * Assert logging an event with `skipLogging` method returns false.
+     *
+     * @return void
+     */
+    public function testSkipLoggingFalse(): void
+    {
+        $instance = new EventsSubscriber($this->app->make(LogManager::class), 'test_events_channel');
+
+        $instance->writeEventIntoLog($event = new Stubs\LoggableEventSkipLoggingStub(true));
+
+        $this->assertLogFileNotExists();
+    }
 }

--- a/tests/Listeners/Stubs/LoggableEventSkipLoggingStub.php
+++ b/tests/Listeners/Stubs/LoggableEventSkipLoggingStub.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace AvtoDev\EventsLogLaravel\Tests\Listeners\Stubs;
+
+use Illuminate\Support\Str;
+
+class LoggableEventSkipLoggingStub extends LoggableEventStub
+{
+    /**
+     * @var bool
+     */
+    protected $skip_logging;
+
+    /**
+     * LoggableEventLogWhenStub constructor.
+     *
+     * @param bool $skip_logging
+     */
+    public function __construct(bool $skip_logging = true)
+    {
+        $this->skip_logging = $skip_logging;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function logMessage(): string
+    {
+        static $result = null;
+
+        if ($result === null) {
+            $result = Str::random(32);
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return bool
+     */
+    public function skipLogging(): bool
+    {
+        return $this->skip_logging;
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | No
| New feature?  | Yes

## Description

Added `logWhen` method like in [laravel Broadcasting](https://laravel.com/docs/5.7/broadcasting#defining-broadcast-events). 

Fixes #1

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code
- [x] I have made changes in [CHANGELOG.md](https://github.com/avto-dev/events-log-laravel/blob/master/CHANGELOG.md) file